### PR TITLE
Bugfix/dashboard units

### DIFF
--- a/airquality_dc/config/config.toml
+++ b/airquality_dc/config/config.toml
@@ -2,7 +2,7 @@
     machine="Machine_1"	#Name of the machine being monitored (can't have spaces)
 
 [adc]
-    # uncomment the adc that you are using (default is BCRobotics)
+    # uncomment the sensor that you are using
     adc_module = "ens160"
 
 [sampling]

--- a/airquality_dc/config/config.toml
+++ b/airquality_dc/config/config.toml
@@ -2,7 +2,7 @@
     machine="Machine_1"	#Name of the machine being monitored (can't have spaces)
 
 [adc]
-    # uncomment the sensor that you are using
+    # uncomment the adc that you are using (default is BCRobotics)
     adc_module = "ens160"
 
 [sampling]

--- a/dashboard_ui/config/dashboards/AirQualityMonitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/AirQualityMonitoring/dashboard.json
@@ -36,6 +36,98 @@
       "fieldConfig": {
         "defaults": {
           "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 1500,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "conppb"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 18,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "influxdb"
+          },
+          "query": "from(bucket: \"airquality_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"airquality_monitoring\")\n  |> filter(fn: (r) => r[\"_field\"] == \"TVOC\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "refId": "A"
+        }
+      ],
+      "title": "VOC History",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
             "mode": "thresholds"
           },
           "mappings": [],
@@ -73,7 +165,7 @@
       "gridPos": {
         "h": 7,
         "w": 6,
-        "x": 0,
+        "x": 18,
         "y": 0
       },
       "id": 10,
@@ -144,7 +236,7 @@
             }
           },
           "mappings": [],
-          "max": 1500,
+          "max": 5000,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
@@ -159,17 +251,17 @@
               }
             ]
           },
-          "unit": "conppb"
+          "unit": "ppm"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 6,
-        "y": 0
+        "w": 18,
+        "x": 0,
+        "y": 7
       },
-      "id": 2,
+      "id": 4,
       "options": {
         "legend": {
           "calcs": [],
@@ -188,11 +280,11 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"airquality_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"airquality_monitoring\")\n  |> filter(fn: (r) => r[\"_field\"] == \"TVOC\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"airquality_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"airquality_monitoring\")\n  |> filter(fn: (r) => r[\"_field\"] == \"CO2\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
-      "title": "VOC History",
+      "title": "CO2 History",
       "type": "timeseries"
     },
     {
@@ -240,7 +332,7 @@
       "gridPos": {
         "h": 7,
         "w": 6,
-        "x": 0,
+        "x": 18,
         "y": 7
       },
       "id": 9,
@@ -311,7 +403,7 @@
             }
           },
           "mappings": [],
-          "max": 5000,
+          "max": 5,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
@@ -325,18 +417,17 @@
                 "value": 80
               }
             ]
-          },
-          "unit": "ppm"
+          }
         },
         "overrides": []
       },
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 6,
-        "y": 7
+        "w": 18,
+        "x": 0,
+        "y": 14
       },
-      "id": 4,
+      "id": 6,
       "options": {
         "legend": {
           "calcs": [],
@@ -355,11 +446,11 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"airquality_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"airquality_monitoring\")\n  |> filter(fn: (r) => r[\"_field\"] == \"CO2\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"airquality_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"airquality_monitoring\")\n  |> filter(fn: (r) => r[\"_field\"] == \"AQI\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
-      "title": "CO2 History",
+      "title": "AQI History",
       "type": "timeseries"
     },
     {
@@ -410,7 +501,7 @@
       "gridPos": {
         "h": 7,
         "w": 6,
-        "x": 0,
+        "x": 18,
         "y": 14
       },
       "id": 8,
@@ -439,97 +530,6 @@
       ],
       "title": "AQI",
       "type": "gauge"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "influxdb"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "max": 5,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 6,
-        "y": 14
-      },
-      "id": 6,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "influxdb"
-          },
-          "query": "from(bucket: \"airquality_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"airquality_monitoring\")\n  |> filter(fn: (r) => r[\"_field\"] == \"AQI\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
-          "refId": "A"
-        }
-      ],
-      "title": "AQI History",
-      "type": "timeseries"
     }
   ],
   "refresh": "5s",
@@ -566,13 +566,13 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Air Quality Monitoring",
   "uid": "0QKtTznSk",
-  "version": 4,
+  "version": 5,
   "weekStart": ""
 }

--- a/dashboard_ui/config/dashboards/AirQualityMonitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/AirQualityMonitoring/dashboard.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 7,
+  "id": 2,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -49,20 +49,20 @@
                 "value": null
               },
               {
-                "color": "dark-green",
-                "value": 0
+                "color": "semi-dark-green",
+                "value": 200
               },
               {
                 "color": "yellow",
-                "value": 50
+                "value": 400
               },
               {
                 "color": "red",
-                "value": 750
+                "value": 600
               },
               {
                 "color": "semi-dark-red",
-                "value": 1500
+                "value": 800
               }
             ]
           },
@@ -71,7 +71,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
+        "h": 7,
         "w": 6,
         "x": 0,
         "y": 0
@@ -144,7 +144,7 @@
             }
           },
           "mappings": [],
-          "max": 6000,
+          "max": 1500,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
@@ -159,12 +159,12 @@
               }
             ]
           },
-          "unit": "ppm"
+          "unit": "conppb"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
+        "h": 7,
         "w": 12,
         "x": 6,
         "y": 0
@@ -206,7 +206,7 @@
             "mode": "thresholds"
           },
           "mappings": [],
-          "max": 1500,
+          "max": 5000,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
@@ -217,19 +217,19 @@
               },
               {
                 "color": "green",
-                "value": 600
+                "value": 500
               },
               {
                 "color": "yellow",
-                "value": 800
-              },
-              {
-                "color": "orange",
                 "value": 1000
               },
               {
-                "color": "semi-dark-red",
+                "color": "orange",
                 "value": 1500
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 3000
               }
             ]
           },
@@ -238,10 +238,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 6,
         "x": 0,
-        "y": 9
+        "y": 7
       },
       "id": 9,
       "options": {
@@ -311,7 +311,7 @@
             }
           },
           "mappings": [],
-          "max": 21500,
+          "max": 5000,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
@@ -326,15 +326,15 @@
               }
             ]
           },
-          "unit": "conppb"
+          "unit": "ppm"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 12,
         "x": 6,
-        "y": 9
+        "y": 7
       },
       "id": 4,
       "options": {
@@ -408,10 +408,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 6,
         "x": 0,
-        "y": 17
+        "y": 14
       },
       "id": 8,
       "options": {
@@ -500,10 +500,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 12,
         "x": 6,
-        "y": 17
+        "y": 14
       },
       "id": 6,
       "options": {
@@ -573,6 +573,6 @@
   "timezone": "",
   "title": "Air Quality Monitoring",
   "uid": "0QKtTznSk",
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }

--- a/dashboard_ui/config/dashboards/AirQualityMonitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/AirQualityMonitoring/dashboard.json
@@ -142,10 +142,14 @@
               },
               {
                 "color": "semi-dark-green",
-                "value": 200
+                "value": 75
               },
               {
                 "color": "yellow",
+                "value": 200
+              },
+              {
+                "color": "orange",
                 "value": 400
               },
               {
@@ -153,7 +157,7 @@
                 "value": 600
               },
               {
-                "color": "semi-dark-red",
+                "color": "dark-red",
                 "value": 800
               }
             ]
@@ -320,8 +324,12 @@
                 "value": 1500
               },
               {
-                "color": "semi-dark-red",
-                "value": 3000
+                "color": "red",
+                "value": 2500
+              },
+              {
+                "color": "dark-red",
+                "value": 3500
               }
             ]
           },
@@ -474,24 +482,20 @@
                 "value": null
               },
               {
-                "color": "dark-green",
+                "color": "green",
                 "value": 1
               },
               {
-                "color": "semi-dark-green",
+                "color": "yellow",
                 "value": 2
               },
               {
-                "color": "yellow",
+                "color": "orange",
                 "value": 3
               },
               {
                 "color": "dark-red",
                 "value": 4
-              },
-              {
-                "color": "dark-red",
-                "value": 5
               }
             ]
           }
@@ -573,6 +577,6 @@
   "timezone": "",
   "title": "Air Quality Monitoring",
   "uid": "0QKtTznSk",
-  "version": 5,
+  "version": 10,
   "weekStart": ""
 }

--- a/dashboard_ui/config/dashboards/AirQualityMonitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/AirQualityMonitoring/dashboard.json
@@ -117,7 +117,7 @@
           "refId": "A"
         }
       ],
-      "title": "VOC History",
+      "title": "Volatile Organic Compounds History",
       "type": "timeseries"
     },
     {
@@ -196,7 +196,7 @@
           "refId": "A"
         }
       ],
-      "title": "VOC",
+      "title": "Volatile Organic Compounds:",
       "type": "gauge"
     },
     {
@@ -288,7 +288,7 @@
           "refId": "A"
         }
       ],
-      "title": "CO2 History",
+      "title": "Carbon Dioxide History",
       "type": "timeseries"
     },
     {
@@ -367,7 +367,7 @@
           "refId": "A"
         }
       ],
-      "title": "CO2",
+      "title": "Carbon Dioxide:",
       "type": "gauge"
     },
     {
@@ -458,7 +458,7 @@
           "refId": "A"
         }
       ],
-      "title": "AQI History",
+      "title": "Air Quality Index History",
       "type": "timeseries"
     },
     {
@@ -532,7 +532,7 @@
           "refId": "A"
         }
       ],
-      "title": "AQI",
+      "title": "Air Quality Index:",
       "type": "gauge"
     }
   ],
@@ -570,13 +570,13 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Air Quality Monitoring",
   "uid": "0QKtTznSk",
-  "version": 10,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
Minor edits to the dashboard of Air Quality Monitoring. 

- The scales on the graphs and gauges have been changed. For each property (VOC, CO2, AQI) the graph and gauge have the same minimum and maximum. 
 
- The VOC gauge colour banding has been rescaled according to guidelines from WHO and others: <50ppb is good outdoors, <200ppb is good indoors, <400ppb is acceptable, 600ppb is poor and irritation may be observed, 800ppb requires corrective action etc. Similarly, CO2 scale has been adjusted to maintain relevance to human breathability: you know the air is bad long before 5000ppm. These are only defaults, if industrial users want to sample chambers unsafe for workers they can edit the dashboard. 

- The gauges have been moved to the right hand side of the graphs. Given that graphs conventionally display time series data from left to right, with the more recent data at the right hand edge, I feel this is an intuitive place for the gauge displaying the most recent data point. Having the gauge at the left make me question if instead it was an average over the displayed time range. 