### PR TITLE
Remove string wrappers from results payload

### DIFF
--- a/airquality_dc/code/measure.py
+++ b/airquality_dc/code/measure.py
@@ -115,7 +115,7 @@ class AirQualityMeasureBuildingBlock(multiprocessing.Process):
             timestamp = datetime.datetime.now(tz=tz).isoformat()
 
             # convert
-            results = {"TVOC": str(sample.tvoc), "CO2": str(sample.ppm), "AQI": str(sample.aqi)}
+            results = {"TVOC": sample.tvoc, "CO2": sample.ppm, "AQI": sample.aqi}
             payload = {**results, **self.constants, "timestamp": timestamp}
 
                 # send


### PR DESCRIPTION
Remove strings

Much like [we did for Temperature](https://github.com/DigitalShoestringSolutions/TemperatureMonitoring/pull/15/files), this removes the `str()` wrappers from the datapoints in the MQTT payload. 
Doing this improves integration with MDEP.