### PR TITLE
Discard old data before sampling and raise sampling errors

### DIFF
--- a/airquality_dc/code/measure.py
+++ b/airquality_dc/code/measure.py
@@ -95,10 +95,12 @@ class AirQualityMeasureBuildingBlock(multiprocessing.Process):
             t += period
 
             # Collect samples from ADC
+            sample = None                # discard old sample in case below fails
             try:
                 sample = adc.sample()
             except Exception as e:
                 logger.error(f"Sampling lead to exception{e}")
+                raise e                  # -> restart container. If not, would happen in L120 anyway.
 
             # handle timestamps and timezones
             if time.time() > next_check:


### PR DESCRIPTION
This PR is a copy of recent changes in APM (https://github.com/DigitalShoestringSolutions/AirParticleMonitoring/pull/15)
 
I'm agreed that the proper fix for https://github.com/DigitalShoestringSolutions/AirParticleMonitoring/issues/13, which also applies to this repo, is to replace the whole sensing module, but while that's not progressing with any pace here is a very simple patch.

If sampling does raise an error, this will restart the docker container. To me that sounds like the correct behaviour.