### PR TITLE
Bugfix / sample rate

### DIFF
--- a/airquality_dc/code/measure.py
+++ b/airquality_dc/code/measure.py
@@ -53,7 +53,6 @@ class AirQualityMeasureBuildingBlock(multiprocessing.Process):
         self.zmq_out = None
 
         self.collection_interval = config['sampling']['sample_interval']
-        self.sample_count = config['sampling']['sample_count']
         self.adc_module = config['adc']['adc_module']
         logger.info(f"read adc module {self.adc_module} from config")
 

--- a/airquality_dc/config/config.toml
+++ b/airquality_dc/config/config.toml
@@ -6,8 +6,7 @@
     adc_module = "ens160"
 
 [sampling]
-    sample_count = 5
-    sample_interval = 0.2
+    sample_interval = 1
 
 [computing]
 	hardware="Pi4"


### PR DESCRIPTION
Just as APM needed [Hotfix/sampe rate#12](https://github.com/DigitalShoestringSolutions/AirParticleMonitoring/pull/12), this repo suffers the same.

Data is being sent over MQTT at 5Hz, but it's only being updated at 1Hz:
![image](https://github.com/user-attachments/assets/837cd10c-0500-4635-b375-c07267467acb)

![image](https://github.com/user-attachments/assets/23b12f08-5eb0-4b18-9399-5be91842aaf9)

(Note that in this case the compensated sleep is working admirably well!)

Surprising thing is we didn't notice sooner. Unlike the APM sensor, the ENS160 can manage a 5Hz sample rate.

- Remove sample count and change sample_interval from 0.2 to 1
- Removed loading of sample_count in measure.py