### PR TITLE
Rename CO2 to eCO2

### DIFF
--- a/airquality_dc/code/adc/ens160.py
+++ b/airquality_dc/code/adc/ens160.py
@@ -76,7 +76,7 @@ class ADC:
     def sample(self):
         data = Data()
         data.tvoc = self.adc.get_TVOC_ppb
-        data.ppm = self.adc.get_ECO2_ppm
+        data.eco2 = self.adc.get_ECO2_ppm
         data.aqi = self.adc.get_AQI
         return data
 

--- a/airquality_dc/code/measure.py
+++ b/airquality_dc/code/measure.py
@@ -116,7 +116,7 @@ class AirQualityMeasureBuildingBlock(multiprocessing.Process):
             timestamp = datetime.datetime.now(tz=tz).isoformat()
 
             # convert
-            results = {"TVOC": sample.tvoc, "CO2": sample.ppm, "AQI": sample.aqi}
+            results = {"TVOC": sample.tvoc, "eCO2": sample.eco2, "AQI": sample.aqi}
             payload = {**results, **self.constants, "timestamp": timestamp}
 
                 # send

--- a/dashboard_ui/config/dashboards/AirQualityMonitoring/all_sensors.json
+++ b/dashboard_ui/config/dashboards/AirQualityMonitoring/all_sensors.json
@@ -284,11 +284,11 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"${const_bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"airquality_monitoring\")\n  |> filter(fn: (r) => r[\"_field\"] == \"CO2\")\n  |> keep(columns: [\"_time\", \"machine\", \"_value\"]) // removes field name from legend\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)",
+          "query": "from(bucket: \"${const_bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"airquality_monitoring\")\n  |> filter(fn: (r) => r[\"_field\"] == \"eCO2\")\n  |> keep(columns: [\"_time\", \"machine\", \"_value\"]) // removes field name from legend\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)",
           "refId": "A"
         }
       ],
-      "title": "Carbon Dioxide History",
+      "title": "Equivalent Carbon Dioxide History",
       "type": "timeseries"
     },
     {
@@ -363,11 +363,11 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"${const_bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"airquality_monitoring\")\n  |> filter(fn: (r) => r[\"_field\"] == \"CO2\")\n  |> keep(columns: [\"_time\", \"machine\", \"_value\"]) // removes field name from legend\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"${const_bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"airquality_monitoring\")\n  |> filter(fn: (r) => r[\"_field\"] == \"eCO2\")\n  |> keep(columns: [\"_time\", \"machine\", \"_value\"]) // removes field name from legend\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
-      "title": "Carbon Dioxide:",
+      "title": "Equivalent Carbon Dioxide:",
       "type": "gauge"
     },
     {

--- a/dashboard_ui/config/dashboards/AirQualityMonitoring/single_sensor.json
+++ b/dashboard_ui/config/dashboards/AirQualityMonitoring/single_sensor.json
@@ -367,7 +367,7 @@
           "refId": "A"
         }
       ],
-      "title": "Carbon Dioxide:",
+      "title": "Equivalent Carbon Dioxide:",
       "type": "gauge"
     },
     {

--- a/dashboard_ui/config/dashboards/AirQualityMonitoring/single_sensor.json
+++ b/dashboard_ui/config/dashboards/AirQualityMonitoring/single_sensor.json
@@ -284,11 +284,11 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"${const_bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"airquality_monitoring\")\n  |> filter(fn: (r) => r[\"_field\"] == \"CO2\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> keep(columns: [\"_time\", \"machine\", \"_value\"]) // removes field name from legend\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)",
+          "query": "from(bucket: \"${const_bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"airquality_monitoring\")\n  |> filter(fn: (r) => r[\"_field\"] == \"eCO2\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> keep(columns: [\"_time\", \"machine\", \"_value\"]) // removes field name from legend\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)",
           "refId": "A"
         }
       ],
-      "title": "Carbon Dioxide History",
+      "title": "Equivalent Carbon Dioxide History",
       "type": "timeseries"
     },
     {
@@ -363,7 +363,7 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"${const_bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"airquality_monitoring\")\n  |> filter(fn: (r) => r[\"_field\"] == \"CO2\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"${const_bucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"airquality_monitoring\")\n  |> filter(fn: (r) => r[\"_field\"] == \"eCO2\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],

--- a/timeseries_sds/config/telegraf.conf
+++ b/timeseries_sds/config/telegraf.conf
@@ -29,7 +29,7 @@ qos = 1
 			path = "TVOC" # A string with valid GJSON path syntax
 			type = "float"
 		[[inputs.mqtt_consumer.json_v2.field]]
-			path = "CO2" # A string with valid GJSON path syntax
+			path = "eCO2" # A string with valid GJSON path syntax
 			type = "float"
 		[[inputs.mqtt_consumer.json_v2.field]]
 			path = "AQI" # A string with valid GJSON path syntax


### PR DESCRIPTION
This PR renames CO2 to eCO2 or Equivalent CO2 for clarity. 

The ENS160 sensor doesn't measure CO2 concentration, but from using this solution one might be lead to believe that it does. It measures hydrogen, ethanol, some other VOCs, and makes an informed estimate of the likely CO2 concentration, as these pseudo metrics are easier/cheaper to measure.
For most indoor purposes this is ok, as the correlation is based on human breathing.
However as we increase our presence in agritech we need to be clear that this is unsuitable for use in a greenshouse etc. In environments where the CO2 alone may be elevated we need a true CO2 sensor - NDIR / photoacoustic etc.
