### PR TITLE
Resend power mode every sample in ens160.py

### DIFF
--- a/airquality_dc/code/adc/ens160.py
+++ b/airquality_dc/code/adc/ens160.py
@@ -74,6 +74,7 @@ class ADC:
         logger.info("ens160 sensor initialize successfully!!!")
 
     def sample(self):
+        self.adc.set_PWR_mode(sensor.ENS160_STANDARD_MODE) # resend power mode every sample in case of sensor reset
         data = Data()
         data.tvoc = self.adc.get_TVOC_ppb
         data.eco2 = self.adc.get_ECO2_ppm

--- a/airquality_dc/code/adc/ens160.py
+++ b/airquality_dc/code/adc/ens160.py
@@ -49,6 +49,8 @@ class ADC:
                 logger.error(f"Unable to import module DFRobot_ENS160_ROCK. Stopping!!")
                 return
             self.adc = sensor.DFRobot_ENS160_I2C(i2c_addr = 0x53, bus = 7)
+
+        self.sensor = sensor # keep whole module available for later
         
              
         while (self.adc.begin() == False):
@@ -74,7 +76,7 @@ class ADC:
         logger.info("ens160 sensor initialize successfully!!!")
 
     def sample(self):
-        self.adc.set_PWR_mode(sensor.ENS160_STANDARD_MODE) # resend power mode every sample in case of sensor reset
+        self.adc.set_PWR_mode(self.sensor.ENS160_STANDARD_MODE) # resend power mode every sample in case of sensor reset
         data = Data()
         data.tvoc = self.adc.get_TVOC_ppb
         data.eco2 = self.adc.get_ECO2_ppm


### PR DESCRIPTION
Closes #11 

Don't trust the sensor's memory, a small power fluctuation could put it into PoR while the code doesn't notice. Re-write to all registers that matter before each sample. 

This is the same approach [as I took with the picos](https://github.com/DigitalShoestringSolutions/pico-sensing/blob/main/example_user_settings/ens160.py). There the new class instance every sample re-runs __init__ which [includes writing to OPMODE](https://github.com/DigitalShoestringSolutions/pico-sensing/blob/3820446f6a3e09a29e6c95af52faf16e5f18f232/pico_files/sensors/ens160.py#L36)

A more nuanced alternative might read from the OPMODE reg and only overwrite it if it did not match the expected value, or as a pseudometric for that see if AQI is 0 (it's within 1-5 when sensor running). However I don't know of any downside of this blanket approach so simplicity prevails.